### PR TITLE
Added `/version` and `/console` commands

### DIFF
--- a/src/MainModule/SocialChat/Environments/Client/Components/InputBox.lua
+++ b/src/MainModule/SocialChat/Environments/Client/Components/InputBox.lua
@@ -541,6 +541,7 @@ function InputBox:Initialize(Info : table) : metatable
 
     ChatBox:GetPropertyChangedSignal("AbsoluteSize"):Connect(UpdateFontSize);
     ChatBox.Font = Settings.MessageFont
+	InputBox.VERSION = self.VERSION
 
     return self
 end
@@ -763,19 +764,28 @@ function HandleMessage(Message : string) : boolean
         local Channel = Channels:GetFocus();
         if (not Channel) then return true; end
 
-        Channel:Render("Here's a list of chat commands: \n\n **/help** - Provides a list of chat commands \n **/e {emote}** - Plays the provided emote (must be valid) \n **/w {player}** - Allows you to send a private message to the request player. (must use their FULL username)\n **/console** - Opens the developer console for debugging", {
+        Channel:Render("Here's a list of chat commands: \n\n **/help** - Provides a list of chat commands \n **/e {emote}** - Plays the provided emote (must be valid) \n **/w {player}** - Allows you to send a private message to the request player. (must use their FULL username)\n **/console** - Opens the developer console for debugging\n **/version** - Display the version of the chat system being used", {
             ["BypassMarkdownSetting"] = true
         });
         return true;
-    elseif ((#Words == 1) and (Words[1] == "/console" or Words[1] == "/newconsole")) then
+	elseif ((#Words == 1) and (Words[1] == "/console" or Words[1] == "/newconsole")) then
 		local success, isEnabled = pcall(StarterGui.GetCore, StarterGui, "DevConsoleVisible")
 
 		if success then
 			xpcall(StarterGui.SetCore, warn, StarterGui, "DevConsoleVisible", not isEnabled)
 		end
 
-        return true;
-    end
+		return true;
+	elseif ((#Words == 1) and (Words[1] == "/version") or (string.sub(Message, 1, 9) == "/version ")) then
+		local Channel = Channels:GetFocus();
+		if (not Channel) then return true; end
+
+		Channel:Render(string.format("Currently using Social Chat version: %s", InputBox.VERSION or "UNKNOWN VERSION"), {
+			["BypassMarkdownSetting"] = true
+		});
+
+		return true;
+	end
 end
 
 return InputBox

--- a/src/MainModule/SocialChat/Environments/Client/Components/InputBox.lua
+++ b/src/MainModule/SocialChat/Environments/Client/Components/InputBox.lua
@@ -15,6 +15,7 @@ InputBox.__index = InputBox
 local UserInputService = game:GetService("UserInputService");
 local TextService = game:GetService("TextService");
 local RunService = game:GetService("RunService");
+local StarterGui = game:GetService("StarterGui")
 
 --// Imports
 local HighlightUtil
@@ -762,9 +763,17 @@ function HandleMessage(Message : string) : boolean
         local Channel = Channels:GetFocus();
         if (not Channel) then return true; end
 
-        Channel:Render("Here's a list of chat commands: \n\n **/help** - Provides a list of chat commands \n **/e {emote}** - Plays the provided emote (must be valid) \n **/w {player}** - Allows you to send a private message to the request player. (must use their FULL username)", {
+        Channel:Render("Here's a list of chat commands: \n\n **/help** - Provides a list of chat commands \n **/e {emote}** - Plays the provided emote (must be valid) \n **/w {player}** - Allows you to send a private message to the request player. (must use their FULL username)\n **/console** - Opens the developer console for debugging", {
             ["BypassMarkdownSetting"] = true
         });
+        return true;
+    elseif ((#Words == 1) and (Words[1] == "/console" or Words[1] == "/newconsole")) then
+		local success, isEnabled = pcall(StarterGui.GetCore, StarterGui, "DevConsoleVisible")
+
+		if success then
+			xpcall(StarterGui.SetCore, warn, StarterGui, "DevConsoleVisible", not isEnabled)
+		end
+
         return true;
     end
 end

--- a/src/MainModule/SocialChat/Environments/Client/init.lua
+++ b/src/MainModule/SocialChat/Environments/Client/init.lua
@@ -229,7 +229,9 @@ local function Initialize(Setup : table)
             ["Data"] = SocialChatData,
             ["FFLAG_DataFailure"] = DidDataLoadSuccessfully,
 
-            ["Trace"] = Setup.Trace
+            ["Trace"] = Setup.Trace,
+
+			["VERSION"]= Setup.VERSION
         });
 
         ContentReady = true

--- a/src/SocialChatv2/Configurations/Client/Channels.lua
+++ b/src/SocialChatv2/Configurations/Client/Channels.lua
@@ -17,7 +17,7 @@ return {
         ["Phrases"] = {
             "/e dance", "/e dance1", "/e dance2", "/e dance3",
             "/e point", "/e cheer", "/e wave", "/e laugh",
-            "/help", "/w"
+            "/help", "/w", "/console", "/newconsole"
         },
 
         ["Color"] = Color3.fromRGB(233, 75, 75),

--- a/src/SocialChatv2/Configurations/Client/Channels.lua
+++ b/src/SocialChatv2/Configurations/Client/Channels.lua
@@ -17,7 +17,8 @@ return {
         ["Phrases"] = {
             "/e dance", "/e dance1", "/e dance2", "/e dance3",
             "/e point", "/e cheer", "/e wave", "/e laugh",
-            "/help", "/w", "/console", "/newconsole"
+            "/help", "/w", "/console", "/newconsole",
+			"/version", "/version "
         },
 
         ["Color"] = Color3.fromRGB(233, 75, 75),


### PR DESCRIPTION
There are commands in the default Roblox chat so adding this makes it a better experience to use this chat system.

- `/console` and its alias `/newconsole` are an easy way to show the developer console
- `/version` displays the version of the chat system being used